### PR TITLE
feat: --render-path flag

### DIFF
--- a/cmd/entropy.go
+++ b/cmd/entropy.go
@@ -8,6 +8,7 @@ import (
 
 var noBrowserOpen bool
 var enableGui bool
+var renderPath string
 
 func EntropyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -31,8 +32,9 @@ func EntropyCmd() *cobra.Command {
 				return err
 			}
 			err = entropy.Render(parser, entropy.RenderConfig{
-				NoOpen:    noBrowserOpen,
-				EnableGui: enableGui,
+				NoOpen:     noBrowserOpen,
+				EnableGui:  enableGui,
+				RenderPath: renderPath,
 			})
 			return err
 		},
@@ -40,6 +42,7 @@ func EntropyCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&noBrowserOpen, "no-browser-open", false, "Disable the automatic browser open while rendering entropy")
 	cmd.Flags().BoolVar(&enableGui, "enable-gui", false, "Enables a GUI for changing rendering settings")
+	cmd.Flags().StringVar(&renderPath, "render-path", "", "Renders the HTML file in the specified path")
 
 	return cmd
 }

--- a/internal/entropy/render.go
+++ b/internal/entropy/render.go
@@ -19,8 +19,9 @@ const ToReplace = "const DATA = {}"
 const ReplacePrefix = "const DATA = "
 
 type RenderConfig struct {
-	NoOpen    bool
-	EnableGui bool
+	NoOpen     bool
+	EnableGui  bool
+	RenderPath string
 }
 
 func Render(parser language.NodeParser, cfg RenderConfig) error {
@@ -38,15 +39,20 @@ func Render(parser language.NodeParser, cfg RenderConfig) error {
 		return err
 	}
 	rendered := bytes.ReplaceAll(index, []byte(ToReplace), append([]byte(ReplacePrefix), marshaled...))
-	temp := filepath.Join(os.TempDir(), "index.html")
-	err = os.WriteFile(temp, rendered, os.ModePerm)
+
+	renderFile := cfg.RenderPath
+	if renderFile == "" {
+		renderFile = filepath.Join(os.TempDir(), "index.html")
+	}
+
+	err = os.WriteFile(renderFile, rendered, os.ModePerm)
 	if err != nil {
 		return err
 	}
 	if cfg.NoOpen {
-		fmt.Println(temp)
+		fmt.Println(renderFile)
 		return nil
 	} else {
-		return openInBrowser(temp)
+		return openInBrowser(renderFile)
 	}
 }


### PR DESCRIPTION
Creates `render-path` flag, so the user can specify where the HTML file is generated instead of always using the hardcoded `/tmp/index.html`.