### PR TITLE
Add descriptions for dep-tree check

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ check:
 
 ### Example configuration file
 
+A `schema.json` file is provided in https://github.com/gabotechs/dep-tree/blob/main/schema.json which can be
+used in IDEs for providing autocompletion on `.dep-tree.yml` files.
+
 Dep Tree by default will read the configuration file in `.dep-tree.yml`, which is expected to be a file
 that contains the following settings:
 
@@ -360,6 +363,13 @@ check:
     'src/products/**':
       - 'src/products/**'
       - 'src/helpers/**'
+    # additionally, instead of providing a simple list of allowed dependencies, you
+    # can also provide the reason for this restriction to exist, that way, when if the
+    # check fails, an informative error is displayed through stderr.
+    'src/users/**':
+      to:
+        - 'src/helpers/**'
+      reason: The Users domain is only allowed to import helper code, nothing else
 
   # map from glob pattern to array of glob patterns that determines forbidden
   # dependencies. If a file that matches a key glob pattern depends on another
@@ -370,6 +380,14 @@ check:
     # as they are supposed to belong to different domains.
     'src/products/**':
       - 'src/users/**'
+    # additionally, instead of providing a simple list of forbidden dependencies, you
+    # can also provide the reason for each individual restriction to exist. If one of
+    # these rules is broken, the reason will be displayed through stderr
+    'src/users/**':
+      - to: 'src/products/**'
+        reason: The Users domain should not import anything from the Products domain
+      - to: 'src/orders/**'
+        reason: The Users domain should not import anything from the Orders domain
 
   # typically, in a project, there is a set of files that are always good to depend
   # on, because they are supposed to be common helpers, or parts that are actually

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -26,22 +26,38 @@ func Check[T any](
 	if err != nil {
 		return err
 	}
+
 	// 2. Check for rule violations in the graph.
-	failures := make([]string, 0)
+	sb := strings.Builder{}
 	for _, node := range g.AllNodes() {
 		for _, dep := range g.FromId(node.Id) {
 			from, to := cfg.rel(node.Id), cfg.rel(dep.Id)
-			pass, err := cfg.Check(from, to)
+			pass, reason, err := cfg.Check(from, to)
 			if err != nil {
 				return err
 			} else if !pass {
-				failures = append(failures, from+" -> "+to)
+				sb.WriteString("- ")
+				sb.WriteString(from)
+				sb.WriteString(" -> ")
+				sb.WriteString(to)
+				if reason != "" {
+					for _, line := range strings.Split(reason, "\n") {
+						sb.WriteString("\n  ")
+						sb.WriteString(line)
+					}
+				}
+				sb.WriteString("\n")
 			}
 		}
 	}
 	// 3. Check for cycles.
 	cycles := g.RemoveElementaryCycles()
 	if !cfg.AllowCircularDependencies {
+		if len(cycles) > 0 {
+			sb.WriteString("\n")
+			sb.WriteString("detected circular dependencies:")
+			sb.WriteString("\n")
+		}
 		for _, cycle := range cycles {
 			formattedCycleStack := make([]string, len(cycle.Stack))
 			for i, el := range cycle.Stack {
@@ -52,64 +68,66 @@ func Check[T any](
 				}
 			}
 
-			msg := "detected circular dependency: " + strings.Join(formattedCycleStack, " -> ")
-			failures = append(failures, msg)
+			sb.WriteString("- ")
+			sb.WriteString(strings.Join(formattedCycleStack, " -> "))
+			sb.WriteString("\n")
 		}
 	}
-	if len(failures) > 0 {
-		return errors.New("Check failed, the following dependencies are not allowed:\n" + strings.Join(failures, "\n"))
+	errorMsg := sb.String()
+	if len(errorMsg) > 0 {
+		return errors.New("Check failed, the following dependencies are not allowed:\n" + errorMsg)
 	}
 	return nil
 }
 
-func (c *Config) whiteListCheck(from, to string) (bool, error) {
-	for k, v := range c.WhiteList {
+func (c *Config) whiteListCheck(from, to string) (bool, string, error) {
+	for k, rule := range c.WhiteList {
 		doesMatch, err := utils.GlobstarMatch(k, from)
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 		if doesMatch {
-			for _, dest := range v {
+			for _, dest := range rule.To {
 				shouldPass, err := utils.GlobstarMatch(dest, to)
 				if err != nil {
-					return false, err
+					return false, "", err
 				}
 				if shouldPass {
-					return true, nil
+					return true, "", nil
 				}
 			}
-			return false, nil
+			return false, rule.Reason, nil
 		}
 	}
-	return true, nil
+	return true, "", nil
 }
 
-func (c *Config) blackListCheck(from, to string) (bool, error) {
+func (c *Config) blackListCheck(from, to string) (bool, string, error) {
 	for k, v := range c.BlackList {
 		doesMatch, err := utils.GlobstarMatch(k, from)
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 		if doesMatch {
-			for _, dest := range v {
-				shouldReject, err := utils.GlobstarMatch(dest, to)
+			for _, rule := range v {
+				shouldReject, err := utils.GlobstarMatch(rule.To, to)
 				if err != nil {
-					return false, err
+					return false, "", err
 				}
 				if shouldReject {
-					return false, nil
+					return false, rule.Reason, nil
 				}
 			}
 		}
 	}
 
-	return true, nil
+	return true, "", nil
 }
 
-func (c *Config) Check(from, to string) (bool, error) {
-	pass, err := c.blackListCheck(from, to)
+func (c *Config) Check(from, to string) (bool, string, error) {
+	pass, reason, err := c.blackListCheck(from, to)
 	if err != nil || !pass {
-		return pass, err
+		return pass, reason, err
 	}
 	return c.whiteListCheck(from, to)
 }

--- a/internal/check/config.go
+++ b/internal/check/config.go
@@ -2,11 +2,11 @@ package check
 
 type Config struct {
 	Path                      string
-	Entrypoints               []string            `yaml:"entrypoints"`
-	AllowCircularDependencies bool                `yaml:"allowCircularDependencies"`
-	Aliases                   map[string][]string `yaml:"aliases"`
-	WhiteList                 map[string][]string `yaml:"allow"`
-	BlackList                 map[string][]string `yaml:"deny"`
+	Entrypoints               []string                    `yaml:"entrypoints"`
+	AllowCircularDependencies bool                        `yaml:"allowCircularDependencies"`
+	Aliases                   map[string][]string         `yaml:"aliases"`
+	WhiteList                 map[string]WhiteListEntries `yaml:"allow"`
+	BlackList                 map[string][]BlackListEntry `yaml:"deny"`
 }
 
 func (c *Config) Init(path string) {
@@ -15,21 +15,85 @@ func (c *Config) Init(path string) {
 }
 
 func (c *Config) expandAliases() {
-	lists := []map[string][]string{
-		c.WhiteList,
-		c.BlackList,
-	}
-	for _, list := range lists {
-		for k, v := range list {
-			newV := make([]string, 0)
-			for _, entry := range v {
-				if alias, ok := c.Aliases[entry]; ok {
-					newV = append(newV, alias...)
-				} else {
-					newV = append(newV, entry)
-				}
+	for k, entries := range c.WhiteList {
+		newV := make([]string, 0)
+		for _, entry := range entries.To {
+			if aliases, ok := c.Aliases[entry]; ok {
+				newV = append(newV, aliases...)
+			} else {
+				newV = append(newV, entry)
 			}
-			list[k] = newV
+		}
+		c.WhiteList[k] = WhiteListEntries{
+			To:     newV,
+			Reason: entries.Reason,
 		}
 	}
+
+	for k, entries := range c.BlackList {
+		newV := make([]BlackListEntry, 0)
+		for _, entry := range entries {
+			if aliases, ok := c.Aliases[entry.To]; ok {
+				for _, alias := range aliases {
+					newV = append(newV, BlackListEntry{
+						To:     alias,
+						Reason: entry.Reason,
+					})
+				}
+			} else {
+				newV = append(newV, entry)
+			}
+		}
+		c.BlackList[k] = newV
+	}
+}
+
+type BlackListEntry struct {
+	To     string `yaml:"to"`
+	Reason string `yaml:"reason"`
+}
+
+func (v *BlackListEntry) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err == nil {
+		v.To = str
+		return nil
+	}
+	temp := struct {
+		To     string `yaml:"to"`
+		Reason string `yaml:"reason"`
+	}{}
+
+	err := unmarshal(&temp)
+	if err != nil {
+		return err
+	}
+	v.To = temp.To
+	v.Reason = temp.Reason
+	return nil
+}
+
+type WhiteListEntries struct {
+	To     []string `yaml:"to"`
+	Reason string   `yaml:"reason"`
+}
+
+func (v *WhiteListEntries) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var strList []string
+	if err := unmarshal(&strList); err == nil {
+		v.To = strList
+		return nil
+	}
+
+	temp := struct {
+		To     []string `yaml:"to"`
+		Reason string   `yaml:"reason"`
+	}{}
+	err := unmarshal(&temp)
+	if err != nil {
+		return err
+	}
+	v.To = temp.To
+	v.Reason = temp.Reason
+	return nil
 }

--- a/internal/check/config_test.go
+++ b/internal/check/config_test.go
@@ -19,8 +19,8 @@ func TestConfig_Check(t *testing.T) {
 		{
 			Name: "white list passes",
 			Config: Config{
-				WhiteList: map[string][]string{
-					"white": {"**pass**"},
+				WhiteList: map[string]WhiteListEntries{
+					"white": {To: []string{"**pass**"}},
 				},
 			},
 			From:   "white",
@@ -30,8 +30,8 @@ func TestConfig_Check(t *testing.T) {
 		{
 			Name: "white list fails",
 			Config: Config{
-				WhiteList: map[string][]string{
-					"white": {"**pass**"},
+				WhiteList: map[string]WhiteListEntries{
+					"white": {To: []string{"**pass**"}},
 				},
 			},
 			From:   "white",
@@ -41,8 +41,8 @@ func TestConfig_Check(t *testing.T) {
 		{
 			Name: "black list passes",
 			Config: Config{
-				BlackList: map[string][]string{
-					"black": {"**fail**"},
+				BlackList: map[string][]BlackListEntry{
+					"black": {{To: "**fail**"}},
 				},
 			},
 			From:   "black",
@@ -52,8 +52,8 @@ func TestConfig_Check(t *testing.T) {
 		{
 			Name: "black list fails",
 			Config: Config{
-				BlackList: map[string][]string{
-					"black": {"**fail**"},
+				BlackList: map[string][]BlackListEntry{
+					"black": {{To: "**fail**"}},
 				},
 			},
 			From:   "black",
@@ -63,8 +63,8 @@ func TestConfig_Check(t *testing.T) {
 		{
 			Name: "this should never pass",
 			Config: Config{
-				BlackList: map[string][]string{
-					"**": {"**"},
+				BlackList: map[string][]BlackListEntry{
+					"**": {{To: "**"}},
 				},
 			},
 			From:   "black",
@@ -75,7 +75,7 @@ func TestConfig_Check(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			pass, err := tt.Config.Check(tt.From, tt.To)
+			pass, _, err := tt.Config.Check(tt.From, tt.To)
 			a.NoError(err)
 			a.Equal(tt.Passes, pass)
 		})

--- a/internal/config/.config_test/.with-descriptions.yml
+++ b/internal/config/.config_test/.with-descriptions.yml
@@ -1,0 +1,27 @@
+check:
+  entrypoints:
+    - src/index.js
+  aliases:
+    common_1-3:
+      - "1.js"
+      - "2.js"
+      - "3.js"
+    common_4-5:
+      - "4.js"
+      - "5.js"
+  allow:
+    "src/users/**":
+      to:
+        - "src/users/**"
+        - "common_1-3"
+      reason: only users and common allowed
+  deny:
+    "src/products/**":
+      - to: "src/users/**"
+        reason: users not allowed
+      - "src/products/**"
+      - to: "common_1-3"
+        reason: |
+          common 1-3 not allowed,
+          double check your dependencies
+      - "common_4-5"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gabotechs/dep-tree/internal/check"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,8 +17,8 @@ func TestParseConfig(t *testing.T) {
 	tests := []struct {
 		Name              string
 		File              string
-		ExpectedWhiteList map[string][]string
-		ExpectedBlackList map[string][]string
+		ExpectedWhiteList map[string]check.WhiteListEntries
+		ExpectedBlackList map[string][]check.BlackListEntry
 		ExpectedExclude   []string
 	}{
 		{
@@ -26,32 +28,58 @@ func TestParseConfig(t *testing.T) {
 		{
 			Name: "Simple",
 			File: ".parse.yml",
-			ExpectedWhiteList: map[string][]string{
-				"foo": {"bar"},
+			ExpectedWhiteList: map[string]check.WhiteListEntries{
+				"foo": {To: []string{"bar"}},
 			},
-			ExpectedBlackList: map[string][]string{
-				"bar": {"baz"},
+			ExpectedBlackList: map[string][]check.BlackListEntry{
+				"bar": {{To: "baz"}},
 			},
 		},
 		{
 			Name: "Aliased",
 			File: ".aliases.yml",
-			ExpectedWhiteList: map[string][]string{
-				"src/users/**": {
+			ExpectedWhiteList: map[string]check.WhiteListEntries{
+				"src/users/**": {To: []string{
 					"src/users/**",
 					"src/@*/**",
 					"src/config.js",
 					"src/common.js",
+				}},
+			},
+			ExpectedBlackList: map[string][]check.BlackListEntry{
+				"src/products/**": {
+					{To: "src/users/**"},
+					{To: "src/@*/**"},
+					{To: "src/config.js"},
+					{To: "src/common.js"},
+					{To: "src/generated/**"},
+					{To: "generated/**"},
 				},
 			},
-			ExpectedBlackList: map[string][]string{
+		},
+		{
+			Name: "With descriptions",
+			File: ".with-descriptions.yml",
+			ExpectedWhiteList: map[string]check.WhiteListEntries{
+				"src/users/**": {
+					To: []string{
+						"src/users/**",
+						"1.js",
+						"2.js",
+						"3.js",
+					},
+					Reason: "only users and common allowed",
+				},
+			},
+			ExpectedBlackList: map[string][]check.BlackListEntry{
 				"src/products/**": {
-					"src/users/**",
-					"src/@*/**",
-					"src/config.js",
-					"src/common.js",
-					"src/generated/**",
-					"generated/**",
+					{To: "src/users/**", Reason: "users not allowed"},
+					{To: "src/products/**"},
+					{To: "1.js", Reason: "common 1-3 not allowed,\ndouble check your dependencies\n"},
+					{To: "2.js", Reason: "common 1-3 not allowed,\ndouble check your dependencies\n"},
+					{To: "3.js", Reason: "common 1-3 not allowed,\ndouble check your dependencies\n"},
+					{To: "4.js"},
+					{To: "5.js"},
 				},
 			},
 		},
@@ -69,18 +97,16 @@ func TestParseConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			a := require.New(t)
-
 			if tt.File != "" {
 				tt.File = filepath.Join(testFolder, tt.File)
 			}
 			cfg, err := ParseConfigFromFile(tt.File)
-			a.NoError(err)
+			require.NoError(t, err)
 			cfg.EnsureAbsPaths()
 
-			a.Equal(tt.ExpectedWhiteList, cfg.Check.WhiteList)
-			a.Equal(tt.ExpectedBlackList, cfg.Check.BlackList)
-			a.Equal(tt.ExpectedExclude, cfg.Exclude)
+			assert.Equal(t, tt.ExpectedWhiteList, cfg.Check.WhiteList)
+			assert.Equal(t, tt.ExpectedBlackList, cfg.Check.BlackList)
+			assert.Equal(t, tt.ExpectedExclude, cfg.Exclude)
 		})
 	}
 }

--- a/internal/config/sample-config.yml
+++ b/internal/config/sample-config.yml
@@ -55,6 +55,13 @@ check:
     'src/products/**':
       - 'src/products/**'
       - 'src/helpers/**'
+    # additionally, instead of providing a simple list of allowed dependencies, you
+    # can also provide the reason for this restriction to exist, that way, when if the
+    # check fails, an informative error is displayed through stderr.
+    'src/users/**':
+      to:
+       - 'src/helpers/**'
+      reason: The Users domain is only allowed to import helper code, nothing else
 
   # map from glob pattern to array of glob patterns that determines forbidden
   # dependencies. If a file that matches a key glob pattern depends on another
@@ -65,6 +72,14 @@ check:
     # as they are supposed to belong to different domains.
     'src/products/**':
       - 'src/users/**'
+    # additionally, instead of providing a simple list of forbidden dependencies, you
+    # can also provide the reason for each individual restriction to exist. If one of
+    # these rules is broken, the reason will be displayed through stderr
+    'src/users/**':
+      - to: 'src/products/**'
+        reason: The Users domain should not import anything from the Products domain
+      - to: 'src/orders/**'
+        reason: The Users domain should not import anything from the Orders domain
 
   # typically, in a project, there is a set of files that are always good to depend
   # on, because they are supposed to be common helpers, or parts that are actually

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "exclude": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Files that should be completely ignored by dep-tree, typically large files or auto-generated code."
+    },
+    "only": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "The only files to be included by dep-tree. Files not matching these patterns will be ignored."
+    },
+    "unwrapExports": {
+      "type": "boolean",
+      "description": "Determines whether re-exports should be unwrapped to the target file."
+    },
+    "check": {
+      "type": "object",
+      "properties": {
+        "entrypoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The entrypoints to the application. These files act as root nodes for dependency checks."
+        },
+        "allowCircularDependencies": {
+          "type": "boolean",
+          "description": "Whether circular dependencies are allowed in the project."
+        },
+        "allow": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "to": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "A list of file patterns that the parent is allowed to depend on."
+                    },
+                    "reason": {
+                      "type": "string",
+                      "description": "The reason for this restriction to exist."
+                    }
+                  },
+                  "required": ["to"]
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "description": "Defines allowed dependencies for files matching specific patterns, optionally with reasons."
+        },
+        "deny": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "to": {
+                        "type": "string",
+                        "description": "The file pattern to which the parent should never depend on."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "description": "The reason for this restriction to exist."
+                      }
+                    },
+                    "required": ["to"]
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "description": "Defines forbidden dependencies for files matching specific patterns, optionally with reasons."
+        },
+        "aliases": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "description": "Defines aliases for groups of files that are commonly depended upon, such as helpers or utilities."
+        }
+      },
+      "required": [],
+      "description": "Configuration for dependency checks, including allowed and forbidden dependencies, entrypoints, and aliases."
+    },
+    "js": {
+      "type": "object",
+      "properties": {
+        "workspaces": {
+          "type": "boolean",
+          "description": "Whether to account for package.json workspaces when resolving paths."
+        },
+        "tsConfigPaths": {
+          "type": "boolean",
+          "description": "Whether to follow TypeScript tsconfig.json paths for module resolution."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Settings specific to JavaScript and TypeScript projects."
+    },
+    "python": {
+      "type": "object",
+      "properties": {
+        "excludeConditionalImports": {
+          "type": "boolean",
+          "description": "Whether to consider conditional imports as dependencies."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Settings specific to Python projects."
+    },
+    "rust": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings specific to Rust projects (currently none available)."
+    }
+  },
+  "required": [],
+  "additionalProperties": false,
+  "description": "Schema for dep-tree configuration files, used to manage and validate project dependencies."
+}


### PR DESCRIPTION
When performing a `dep-tree check` in the CI, it's useful to throw a useful error to the user so that they know what to fix. This adds the ability to add reasons for a check to fail in the configuration file.

Closes https://github.com/gabotechs/dep-tree/issues/116