### PR TITLE
Add graph file picker to visualization app

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -241,7 +241,7 @@ function FilePicker({ onFilePicked }: { onFilePicked: (file: File | undefined) =
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen w-full text-gray-200">
+    <>
       <h2 className="text-xl font-semibold mb-2">Drop Dep-Tree JSON Graph File Here</h2>
       <p className="text-gray-400 mb-4">or</p>
       <input
@@ -250,7 +250,7 @@ function FilePicker({ onFilePicked }: { onFilePicked: (file: File | undefined) =
         onChange={handleFileSelected}
         className="bg-gray-800 px-4 py-2 rounded cursor-pointer hover:bg-gray-700"
       />
-    </div>
+    </>
   )
 }
 
@@ -298,7 +298,13 @@ function App() {
       {isDragging
         ? <DropPlaceholder />
         : (!graphData.nodes?.length
-          ? <FilePicker onFilePicked={handleFilePicked} />
+          ? <div className="flex flex-col items-center justify-center min-h-screen w-full text-gray-200">
+            <FilePicker onFilePicked={handleFilePicked} />
+            <div className="bg-yellow-600/20 border border-yellow-500/50 rounded-lg px-4 py-2 mt-12 max-w-lg text-center">
+              <span className="text-yellow-500 font-medium">⚠️ Experimental</span>
+              <p className="text-yellow-400/80 text-sm mt-1">This feature relies on an internal structure that may break in the future.</p>
+            </div>
+          </div>
           : <GraphExplorer key={forceRemountKey} graphData={graphData} />)}
     </div>
   )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,7 +54,7 @@ const DEFAULT_SETTINGS = {
 const UNREAL_BLOOM_PASS = new UnrealBloomPass()
 
 function GraphExplorer({ graphData }: { graphData: Graph }) {
-  const { xGraph: X_GRAPH, nodes: NODES, fileTree: FILE_TREE } = useMemo(() => buildXGraph(graphData), [graphData])
+  const { xGraph, nodes, fileTree } = useMemo(() => buildXGraph(graphData), [graphData])
   const [highlightNodes, setHighlightNodes] = useState(new Set<XNode>())
   const [highlightLinks, setHighlightLinks] = useState(new Set<XLink>())
   const [selectedNode, setSelectedNode] = useState<XNode>()
@@ -160,10 +160,10 @@ function GraphExplorer({ graphData }: { graphData: Graph }) {
         if (link.isDir) f = settings.DIR_LINK_STRENGTH_FACTOR
         if (link.isPackage) f = settings.PACKAGE_LINK_STRENGTH_FACTOR
         if (link.ignore) f = 0
-        return f / Math.min(NODES[link.from].neighbors?.length ?? 1, NODES[link.to].neighbors?.length ?? 1);
+        return f / Math.min(nodes[link.from].neighbors?.length ?? 1, nodes[link.to].neighbors?.length ?? 1);
       })
     graph.current?.d3ReheatSimulation()
-  }, [NODES, settings.DIR_LINK_STRENGTH_FACTOR, settings.FILE_LINK_STRENGTH_FACTOR, settings.LINK_DISTANCE, settings.PACKAGE_LINK_STRENGTH_FACTOR, updateForced])
+  }, [nodes, settings.DIR_LINK_STRENGTH_FACTOR, settings.FILE_LINK_STRENGTH_FACTOR, settings.LINK_DISTANCE, settings.PACKAGE_LINK_STRENGTH_FACTOR, updateForced])
 
   useEffect(() => {
     graph.current?.d3Force('charge')
@@ -186,7 +186,7 @@ function GraphExplorer({ graphData }: { graphData: Graph }) {
       <ForceGraph
         ref={graph}
         extraRenderers={[new CSS2DRenderer()]}
-        graphData={X_GRAPH}
+        graphData={xGraph}
         backgroundColor={'#000003'}
         nodeResolution={settings.NODE_RESOLUTION}
         onBackgroundClick={backgroundClick}
@@ -216,13 +216,13 @@ function GraphExplorer({ graphData }: { graphData: Graph }) {
       />
       <Explorer
         className={'fixed top-0 left-0 max-h-full bg-transparent'}
-        fileTree={FILE_TREE}
+        fileTree={fileTree}
         onSelectNode={nodeClick}
         selected={selectedNode}
         highlighted={highlightNodes}
         onNodesMutated={forceUpdate}
       />
-      <Leva hidden={!X_GRAPH.enableGui}/>
+      <Leva hidden={!xGraph.enableGui}/>
     </>
   )
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,7 @@ import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPa
 // @ts-expect-error
 import { CSS2DObject, CSS2DRenderer } from 'three/examples/jsm/renderers/CSS2DRenderer.js'
 import ForceGraph, { ForceGraphMethods, LinkObject, NodeObject } from "react-force-graph-3d";
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Leva, useControls } from "leva";
 
 import { buildXGraph, XLink, XNode } from "./XGraph.ts";
@@ -283,7 +283,7 @@ function App() {
   function handleDrop(e: React.DragEvent<HTMLDivElement>) {
     e.preventDefault()
     setIsDragging(false)
-    handleFilePicked(e.dataTransfer.files[0])
+    void handleFilePicked(e.dataTransfer.files[0])
   }
 
   return (


### PR DESCRIPTION
Resolves #120

I went with the approach 2) and implemented a file picker for the web app.

If the `__INLINE_DATA` is not empty it will use that so that generating visualization from CLI works same as before.
Otherwise if it's empty then then file picker is shown.

I deployed a preview page: https://dep-tree.pages.dev/

Here is the counterpart [implementation](https://github.com/dundalek/stratify/blob/d666913b982664bbc9006770fc32ea990796977a/src/io/github/dundalek/stratify/gabotechs_dep_tree.clj#L12-L42) that generates the JSON graph for Clojure code.

Here is a sample file that can be dropped on to the app: [stratify.json](https://github.com/user-attachments/files/19233215/stratify.json)

File picker screen:

![image](https://github.com/user-attachments/assets/2ada2001-1025-4fcc-b2e4-7941cbf86495)

Visualizing Clojure source code:

![stratify-dep-tree](https://github.com/user-attachments/assets/dee7bb9e-07f7-452d-8630-b5c500da22ee)
